### PR TITLE
Make iPhoneHTTPServer run on recent iOS devices

### DIFF
--- a/Samples/iPhoneHTTPServer/Classes/iPhoneHTTPServerAppDelegate.m
+++ b/Samples/iPhoneHTTPServer/Classes/iPhoneHTTPServerAppDelegate.m
@@ -55,7 +55,8 @@ static const int ddLogLevel = LOG_LEVEL_VERBOSE;
     [self startServer];
     
     // Add the view controller's view to the window and display.
-    [window addSubview:viewController.view];
+    [self.window setRootViewController:viewController];
+
     [window makeKeyAndVisible];
     
     return YES;

--- a/Samples/iPhoneHTTPServer/iPhoneHTTPServer.xcodeproj/project.pbxproj
+++ b/Samples/iPhoneHTTPServer/iPhoneHTTPServer.xcodeproj/project.pbxproj
@@ -399,6 +399,7 @@
 		1D6058940D05DD3E006BFB54 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
 				GCC_PREFIX_HEADER = iPhoneHTTPServer_Prefix.pch;
 				INFOPLIST_FILE = "iPhoneHTTPServer-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
@@ -409,6 +410,7 @@
 		1D6058950D05DD3E006BFB54 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
 				GCC_PREFIX_HEADER = iPhoneHTTPServer_Prefix.pch;
 				INFOPLIST_FILE = "iPhoneHTTPServer-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;


### PR DESCRIPTION
- Target arm64
- Set the root view controller when launching the app

With #1 and this PR, you can clone the repo, open the iPhoneHTTPServer project in Xcode and launch it on an iOS device running a recent version of iOS.